### PR TITLE
build `key2lower` as static by cmake

### DIFF
--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -6,7 +6,7 @@ if(${CMAKE_PROJECT_NAME} STREQUAL "Project")
   message(FATAL_ERROR "cmake should be executed not for 'src' subdirectory, but for the top directory of HPhi.")
 endif(${CMAKE_PROJECT_NAME} STREQUAL "Project")
 
-add_library(key2lower key2lower.c)
+add_library(key2lower STATIC key2lower.c)
 add_executable(fourier fourier.F90)
 add_executable(corplot corplot.F90)
 target_link_libraries(fourier key2lower ${LAPACK_LIBRARIES})


### PR DESCRIPTION
The present version, `make install` moves `fourier` into `$CMAKE_INSTALL_PREFIX/bin` but `key2lower.so` not, and so moved `fourier` does not work since system cannot load `libkey2lower`.
This PR fixes this problem.